### PR TITLE
fix(volumePercentage): prevent volume bar's width from changing.

### DIFF
--- a/Extensions/volumePercentage.js
+++ b/Extensions/volumePercentage.js
@@ -13,7 +13,7 @@
     }
     const ele = document.createElement("span")
     ele.classList.add("volume-percent")
-    ele.setAttribute("style","font-size: 14px; padding-left: 10px")
+    ele.setAttribute("style","font-size: 14px; padding-left: 10px; min-width: 45px;")
     
     volumeBar.append(ele)
     volumeBar.style.flex = "0 1 170px"


### PR DESCRIPTION
The volume bar's width is bigger if the volume-percent's text is '0%' than if it's '100%'.
This commit fixes this by adding a `min-width` CSS property to the `volume-percent` span element.