### PR TITLE
Quick fix for undefined Spotify.Queue

### DIFF
--- a/Extensions/playNext.js
+++ b/Extensions/playNext.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function playNext() {
-    if (!(Spicetify.CosmosAsync && Spicetify.Queue && Spicetify.ContextMenu && Spicetify.URI)) {
+    if (!(Spicetify.CosmosAsync && Spicetify.ContextMenu && Spicetify.URI)) {
         setTimeout(playNext, 200);
         return;
     }
@@ -131,19 +131,20 @@
                 is_queued: true,
             },
         }));
+        const theQueue = await Spicetify.CosmosAsync.get("sp://player/v2/main/queue");
         await Spicetify.CosmosAsync.put("sp://player/v2/main/queue", {
-            queue_revision: Spicetify.Queue?.queueRevision,
+            queue_revision: theQueue?.revision,
             next_tracks: [
                 ...newTracks,
-                ...Spicetify.Queue?.nextTracks.map((track) => ({
-                    uri: track.contextTrack.uri,
+                ...theQueue?.next_tracks.map((track) => ({
+                    uri: track.uri,
                     provider: track.provider,
                     metadata: {
                         is_queued: track.provider === "queue",
                     },
                 })),
             ],
-            prev_tracks: Spicetify.Queue?.prevTracks,
+            prev_tracks: theQueue?.prev_tracks,
         })
             .then(() => Spicetify.showNotification("Added to Play Next"))
             .catch((err) => {

--- a/Extensions/playNext.js
+++ b/Extensions/playNext.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function playNext() {
-    if (!(Spicetify.CosmosAsync && Spicetify.ContextMenu && Spicetify.URI)) {
+    if (!(Spicetify.CosmosAsync && Spicetify.Queue && Spicetify.ContextMenu && Spicetify.URI)) {
         setTimeout(playNext, 200);
         return;
     }
@@ -131,20 +131,19 @@
                 is_queued: true,
             },
         }));
-        const theQueue = await Spicetify.CosmosAsync.get("sp://player/v2/main/queue");
         await Spicetify.CosmosAsync.put("sp://player/v2/main/queue", {
-            queue_revision: theQueue?.revision,
+            queue_revision: Spicetify.Queue?.queueRevision,
             next_tracks: [
                 ...newTracks,
-                ...theQueue?.next_tracks.map((track) => ({
-                    uri: track.uri,
+                ...Spicetify.Queue?.nextTracks.map((track) => ({
+                    uri: track.contextTrack.uri,
                     provider: track.provider,
                     metadata: {
                         is_queued: track.provider === "queue",
                     },
                 })),
             ],
-            prev_tracks: theQueue?.prev_tracks,
+            prev_tracks: Spicetify.Queue?.prevTracks,
         })
             .then(() => Spicetify.showNotification("Added to Play Next"))
             .catch((err) => {


### PR DESCRIPTION
Spicetify.Queue is undefined (_no idea why_) which obviously breaks things; I've just added a quick api request to grab the current queue (theQueue) whenever the addToNext function is called instead of referencing Spotify.Queue. This fixes the issue for me.