### PR TITLE
Fix for skipping live music with liveness

### DIFF
--- a/Extensions/auto-skip/src/constants/skips.js
+++ b/Extensions/auto-skip/src/constants/skips.js
@@ -31,7 +31,7 @@ const SKIPS = {
         check: (meta) => {
             return (
                 ["- live", "live version", "(live)"].some((value) => meta.name.toLowerCase().includes(value)) ||
-                meta?.features?.liveliness > 0.8
+                meta?.features?.liveness > 0.8
             );
         },
         callback: async (meta) => {


### PR DESCRIPTION
The track feature named "liveliness" as part of the check in skips.js should be "liveness", as to be compatible with the Spotify api feature. 

Thanks, and nice extension :) 