### PR TITLE
fix(volumePercentage): use different class name for volume bar selection

### DIFF
--- a/Extensions/volumePercentage.js
+++ b/Extensions/volumePercentage.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function addVolumep() {
-    const volumeBar = document.querySelector(".volume-bar");
+    const volumeBar = document.querySelector(".main-nowPlayingBar-volumeBar");
     if (!(volumeBar && Spicetify.Player)) {
         setTimeout(addVolumep, 200);
         return;


### PR DESCRIPTION
fix for Spotify 1.2.19, but compatible even with 1.2.6