### PR TITLE
feat(full-screen): add current time display in full screen mode

### DIFF
--- a/Extensions/full-screen/src/app.tsx
+++ b/Extensions/full-screen/src/app.tsx
@@ -123,7 +123,8 @@ async function main() {
         repeat: HTMLElement,
         queue: HTMLElement | null,
         invertButton: HTMLElement,
-        lyrics: HTMLElement;
+        lyrics: HTMLElement,
+        timeDisplay: HTMLElement;
 
     const coverImg = new Image();
     const backgroundImg = new Image();
@@ -267,6 +268,12 @@ async function main() {
                 queue = container.querySelector("#fsd-queue")!;
                 queue.onclick = () => toggleQueue();
             }
+        }
+
+        if (CFM.get("showCurrentTime")) {
+            timeDisplay = container.querySelector("#fsd-time-display")!;
+            updateTimeDisplay();
+            setInterval(updateTimeDisplay, 1000);
         }
     }
 
@@ -1363,6 +1370,7 @@ async function main() {
             document.fullscreenEnabled
                 ? createToggle(translations[LOCALE].settings.fullscreen, "enableFullscreen")
                 : "",
+            createToggle(translations[LOCALE].settings.showCurrentTime, "showCurrentTime"),
             headerText(translations[LOCALE].settings.extraHeader),
             createToggle(
                 translations[LOCALE].settings.sidebarQueue,
@@ -1692,6 +1700,14 @@ async function main() {
         default:
             break;
     }
+}
+
+function updateTimeDisplay() {
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, "0");
+    const minutes = now.getMinutes().toString().padStart(2, "0");
+    const seconds = now.getSeconds().toString().padStart(2, "0");
+    timeDisplay.innerText = `${hours}:${minutes}:${seconds}`;
 }
 
 export default main;

--- a/Extensions/full-screen/src/constants/defaults.ts
+++ b/Extensions/full-screen/src/constants/defaults.ts
@@ -35,6 +35,7 @@ export const DEFAULTS: Config = {
         showRemainingTime: false,
         verticalMonitorSupport: false,
         sidebarQueue: false,
+        showCurrentTime: false
     },
     def: {
         lyricsDisplay: true,
@@ -70,6 +71,7 @@ export const DEFAULTS: Config = {
         showRemainingTime: false,
         verticalMonitorSupport: true,
         sidebarQueue: false,
+        showCurrentTime: false
     },
     tvMode: false,
     locale: "en-US",

--- a/Extensions/full-screen/src/resources/locales/en-US.json
+++ b/Extensions/full-screen/src/resources/locales/en-US.json
@@ -126,6 +126,7 @@
             "never": "Never",
             "smart": "Smart"
         },
+        "showCurrentTime": "Show Current Time",
 
         "appearanceHeader": "Advanced/Appearance",
         "appearanceSubHeader": "*(Only change if you know what you are doing!)*",

--- a/Extensions/full-screen/src/services/html-creator.ts
+++ b/Extensions/full-screen/src/services/html-creator.ts
@@ -143,5 +143,10 @@ ${CFM.get("lyricsDisplay") ? `<div id="fad-lyrics-plus-container"></div>` : ""}
             }
     </div>
     ${!CFM.getGlobal("tvMode") ? `<div id="fsd-progress-parent"></div>` : ""}
-</div>`;
+</div>
+${
+    CFM.get("showCurrentTime")
+        ? `<div id="fsd-time-display"></div>`
+        : ""
+}`;
 };

--- a/Extensions/full-screen/src/styles/base.scss
+++ b/Extensions/full-screen/src/styles/base.scss
@@ -407,3 +407,12 @@ body.fsd-activated #full-screen-display {
 .fsd-activated .Root__main-view-overlay {
     z-index: 1000;
 }
+#fsd-time-display {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 24px;
+    color: var(--primary-color);
+    z-index: 100;
+}


### PR DESCRIPTION
Fixes #183

Add an option to display the current time in full screen mode.

* Add `showCurrentTime` setting to `DEFAULTS` in `Extensions/full-screen/src/constants/defaults.ts`.
* Update the `render` function in `Extensions/full-screen/src/app.tsx` to include a time display element and update it every second.
* Add styles for the time display element in `Extensions/full-screen/src/styles/base.scss`.
* Add HTML to include the current time display element in `Extensions/full-screen/src/services/html-creator.ts`.
* Add string for `showCurrentTime` setting in `Extensions/full-screen/src/resources/locales/en-US.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/daksh2k/Spicetify-stuff/issues/183?shareId=4e26c4b0-7790-4609-b551-68862323a685).